### PR TITLE
Improve the theme validation in github actions

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -19,3 +19,22 @@ jobs:
       - name: Run pre-commit checks
         run: |
           uvx pre-commit run --all-files
+
+      - name: Checkout zed repo
+        uses: actions/checkout@v4
+        with:
+          repository: zed-industries/zed
+          path: zed
+
+      - name: Install mold linker
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y mold
+
+      - name: Create scratch_dir
+        run: mkdir -p "${{ runner.temp }}/zed-theme-scratch"
+
+      - name: Run zed-extension
+        run: |
+          cargo run -p extension_cli -- --source-dir $GITHUB_WORKSPACE --output-dir "${{ runner.temp }}/zed-theme-out" --scratch-dir "${{ runner.temp }}/zed-theme-scratch"
+        working-directory: ./zed


### PR DESCRIPTION
This adds in the extension_cli run from the official zed repo. Depending on how valuable the schema validation is in the pre-commit, we may drop that and just use this.